### PR TITLE
Added catch for mapping free_to_read value when the mapped value is 0.

### DIFF
--- a/cfg/cfg.d/zz_rioxx2.pl
+++ b/cfg/cfg.d/zz_rioxx2.pl
@@ -591,6 +591,11 @@ $c->{rioxx2_validate_free_to_read} = sub {
 	my( $repo, $value, $eprint ) = @_;
 
 	my @problems;
+	if ( ref($value) ne 'HASH' )
+        {
+                push @problems, $repo->html_phrase( "rioxx2_validate_rioxx2_free_to_read:not_done_part_free_to_read" );
+                return @problems;
+        }
 	unless( EPrints::Utils::is_set( $value->{free_to_read} ) )
 	{
 		push @problems, $repo->html_phrase( "rioxx2_validate_rioxx2_free_to_read:not_done_part_free_to_read" );


### PR DESCRIPTION
Addresses https://github.com/eprintsug/rioxx2/issues/28
Probably due to pre-RIOXX2 eprints that have had embargoes that have expired.
