### PR TITLE
Add method to get embargo expiry date

### DIFF
--- a/cfg/cfg.d/zz_rioxx2.pl
+++ b/cfg/cfg.d/zz_rioxx2.pl
@@ -441,7 +441,9 @@ $c->{rioxx2_value_free_to_read} = sub {
 
 	return undef unless $document;
 	return { free_to_read => "Yes" } if $document->is_set( "security" ) && $document->value( "security" ) eq "public";
-	return { free_to_read => "Yes", start_date => $document->value( "date_embargo" ) } if $document->is_set( "date_embargo" );
+	
+	return { free_to_read => "Yes", start_date => EPrints::RIOXX2::Utils::get_embargo_lapse_date( $document->value( "date_embargo" ) )} if $document->is_set( "date_embargo" );
+
 	return undef;
 };
 
@@ -452,8 +454,9 @@ $c->{rioxx2_value_license_ref} = sub {
 	return undef unless $document->is_set( "license" );
 	my $license = $document->repository->config( "rioxx2", "license_map", $document->value( "license" ) ); 
 	return undef unless $license;
+
 	my $start_date = $eprint->value( "date" ) if ( !$eprint->is_set( "date_type" ) || $eprint->value( "date_type" ) eq "published" ); 
-	$start_date = $document->value( "date_embargo" ) if $document->is_set( "date_embargo" );
+	$start_date = EPrints::RIOXX2::Utils::get_embargo_lapse_date( $document->value( "date_embargo" ) ) if $document->is_set( "date_embargo" );
 	return { license_ref => $license, start_date => $start_date };
 };
 

--- a/lib/plugins/EPrints/RIOXX2/Utils.pm
+++ b/lib/plugins/EPrints/RIOXX2/Utils.pm
@@ -76,5 +76,54 @@ sub contains_markup
 	return scalar @$start_events;
 }
 
+sub get_embargo_lapse_date
+{
+	my( $value ) = @_;
+
+	if( defined $value && $value =~ /^\d{4}/ ) #possibly partial date - but at least a full year
+	{
+		my( $year, $month, $day ) = split( "-", $value );
+
+		# basic map of days in month
+		my @monthDays= qw( 31 28 31 30 31 30 31 31 30 31 30 31 );
+		# fixed for leap years
+		if (($year % 4 == 0 && $year % 100 != 0) || ($year % 400 == 0)) {
+			$monthDays[1] = 29;  # leap year
+		}
+
+		if( !defined $month && !defined $day )
+		{
+			# an embargo date of '2017' will be released after the end of 2017:  2018-01-01.
+			$day = 1;
+			$month = 1;
+			$year++;
+		}
+		elsif( !defined $day )
+		{
+			# an embargo date of '2017-07' will be released after the end of July 2017: 2017-08-01.
+			$day = 1;
+			$month++;
+                }
+		else
+		{
+			if( $day >= $monthDays[$month-1] ){
+				$day = 1;
+				$month++;
+			} else {
+				$day++;
+			}
+		}
+
+		if( $month > 12 ){
+			$month = 1;
+			$year++;
+		}
+
+		return sprintf( "%04d-%02d-%02d", $year, $month, $day );
+	}
+	
+	return undef;
+}
+
 1;
 


### PR DESCRIPTION
Fixes #36 
Allows iso-8601 compliant dates to be obtained from possibly incomplete embargo dates e.g. EPrints allows '2016' as an embargo date - which will expire after the end of 2016 (based on current workings of ~/bin/lift_embargos in EPrints 3.3).
